### PR TITLE
Jekyll 배포를 위한 Ruby 버전 업데이트:

### DIFF
--- a/.github/workflows/jekyll-deploy.yml
+++ b/.github/workflows/jekyll-deploy.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          ruby-version: '3.3.0'
           bundler-cache: true
       
       - name: Setup Pages


### PR DESCRIPTION
 jekyll-deploy.yml 파일에서 Ruby 버전을 3.1에서 3.3.0으로 변경했습니다.